### PR TITLE
Allow user to set image colormap

### DIFF
--- a/python/lsst/display/matplotlib/matplotlib.py
+++ b/python/lsst/display/matplotlib/matplotlib.py
@@ -97,6 +97,7 @@ class DisplayImpl(virtualDevice.DisplayImpl):
         self._interpretMaskBits = interpretMaskBits # interpret mask bits in mtv
         self._mtvOrigin = mtvOrigin
         self._mappable = None
+        self._image_colormap = pyplot.cm.gray
         #
         self.__alpha = unicodedata.lookup("GREEK SMALL LETTER alpha") # used in cursor display string
         self.__delta = unicodedata.lookup("GREEK SMALL LETTER delta") # used in cursor display string
@@ -148,6 +149,16 @@ class DisplayImpl(virtualDevice.DisplayImpl):
         if show:
             if self._mappable:
                 self._figure.colorbar(self._mappable)
+
+    def _setImageColormap(self, cmap):
+        """Set the colormap used for th eimage"""
+        self._image_colormap = cmap
+
+    # This will eventually be moved into Display
+    def setImageColormap(self, cmap):
+        """Set the colormap used for th eimage"""
+        self._setImageColormap(cmap)
+
     #
     # Defined API
     #
@@ -282,7 +293,7 @@ class DisplayImpl(virtualDevice.DisplayImpl):
             cmap = mpColors.ListedColormap(colors)
             norm = mpColors.NoNorm()
         else:
-            cmap = pyplot.cm.gray
+            cmap = self._image_colormap
             norm = self._normalize
 
         ax = self._figure.gca()

--- a/tests/test_display_matplotlib.py
+++ b/tests/test_display_matplotlib.py
@@ -38,6 +38,17 @@ class DisplayMatplotlibTestCase(unittest.TestCase):
         """Set the default backend to this package"""
         afwDisplay.setDefaultBackend("matplotlib")
 
+    def testSetImageColormap(self):
+        """This is a stand-in for an eventual testcase for changing image colormap
+        The basic outline should look something like:
+
+        afwDisplay.setDefaultBackend("matplotlib")
+        display = afwDisplay.Display()
+        display.setImageColormap('viridis')
+        assert display._image_colormap == 'viridis'
+        """
+        pass
+
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 


### PR DESCRIPTION
@rhl this is my first attempt at implementing a facility to allow the user to set the image colormap (#1 and [DM-15182](https://jira.lsstcorp.org/browse/DM-15182). Some notes:
* I've implemented both public (`setImageColormap`) and protected (`_setImageColormap`) methods with the idea that the public method would be eventually moved upstream to `afwDisplay`. (I'm not sure about the naming convention because the preceding function, `show_colorbar`, does not seem to conform with other methods in `Display`.)
* I've inserted a stand-in for testing this facility in [test_display_matplotlib.py](https://github.com/kadrlica/display_matplotlib/blob/cf238d31ef75066e1b8729a3a6e55c7ea473678e/tests/test_display_matplotlib.py#L41-L50). The test is currently commented out because I'm not sure whether we want to handle the creation of the display in `setUp`.