### PR TITLE
Update ellipse plotting in 'dot'

### DIFF
--- a/python/lsst/display/matplotlib/matplotlib.py
+++ b/python/lsst/display/matplotlib/matplotlib.py
@@ -366,8 +366,11 @@ class DisplayImpl(virtualDevice.DisplayImpl):
         if isinstance(symb, afwGeom.ellipses.BaseCore):
             from matplotlib.patches import Ellipse
 
-            axis.add_artist(Ellipse((c + x0, r + y0), xradius=symb.getA(), yradius=symb.getB(),
-                                          rot_deg=math.degrees(symb.getTheta()), color=ctype))
+            # Following matplotlib.patches.Ellipse documentation 'width' and 'height' are diameters while 
+            # 'angle' is rotation in degrees (anti-clockwise)
+            axis.add_artist(Ellipse((c + x0, r + y0), height=2*symb.getA(), width=2*symb.getB(),
+                                    angle=90.+math.degrees(symb.getTheta()), 
+                                    edgecolor=ctype, facecolor='none'))
         elif symb == 'o':
             from matplotlib.patches import CirclePolygon as Circle
 


### PR DESCRIPTION
This updates ("fixes"?) ellipse plotting with `Display.dot` (#2 and [DM-15194](https://jira.lsstcorp.org/browse/DM-15194)). Below I've attached a demonstration image. It looks like the orientations are correct (some finagling to get the position angle right), but the sizes may be too small (I'm not sure what isophot the ellipse is intended to correspond to).

![image](https://user-images.githubusercontent.com/5605123/43232794-49e95aba-9038-11e8-9f2a-dc52f4f6bcc3.png)

I tried to confirm with [`Firefly.ipynb`](https://github.com/lsst-sqre/notebook-demo/blob/master/Firefly.ipynb), but I wasn't able to get Firefly to plot ellipses from `source.getShape`.

Tagging @rhl and @jdswinbank who have been following this issue.