### PR TITLE
DM-20551: Add a number of bug-fixes and requested features to display_matplotlib

### DIFF
--- a/examples/display_matplotlib.ipynb
+++ b/examples/display_matplotlib.ipynb
@@ -44,7 +44,7 @@
     }
    ],
    "source": [
-    "import lsst.afw.geom as afwGeom\n",
+    "import lsst.geom as geom\n",
     "import lsst.afw.image as afwImage\n",
     "import lsst.afw.math as afwMath\n",
     "\n",
@@ -56,7 +56,7 @@
     "im.image[0, 0, afwImage.LOCAL] = 20\n",
     "im.mask[10, 5] = im.mask.getPlaneBitMask(\"EDGE\")\n",
     "im.image[-1, -1, afwImage.LOCAL] = 30\n",
-    "im.image[afwGeom.BoxI(afwGeom.PointI(50, 22), afwGeom.ExtentI(1, 2))] = 40\n",
+    "im.image[geom.BoxI(geom.PointI(50, 22), geom.ExtentI(1, 2))] = 40\n",
     "im.mask[50, 22] = 0x5\n",
     "\n",
     "disp.scale(\"asinh\", \"zscale\", Q=8)\n",
@@ -75,7 +75,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "096f5b9e684b4737962072f3fcf31326",
+       "model_id": "",
        "version_major": 2,
        "version_minor": 0
       },
@@ -88,8 +88,7 @@
     }
    ],
    "source": [
-    "if True:\n",
-    "    disp = afwDisplay.Display(reopenPlot=True)\n",
+    "disp = afwDisplay.Display(reopenPlot=True)\n",
     "\n",
     "if True:\n",
     "    disp.scale(\"asinh\", \"zscale\", Q=8)\n",
@@ -159,7 +158,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7be077d6b5634de3a895ddedcec7e6ea",
+       "model_id": "832e72ed61cf47ee9859c0a6bec58518",
        "version_major": 2,
        "version_minor": 0
       },
@@ -228,11 +227,46 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "### Test ignoring mask planes when setting the scale\n",
+    "N.b. doesn't currently work with `zscale`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9518ae12903a42449f82b43e9939ab3c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FigureCanvasNbAgg()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "im = afwImage.MaskedImageF(100, 50)\n",
+    "afwMath.randomGaussianImage(im.image, afwMath.Random())\n",
+    "\n",
+    "sim = im[geom.BoxI(geom.PointI(0, 0), geom.ExtentI(im.getWidth()//2, im.getHeight()))]\n",
+    "sim.image[:] = 100\n",
+    "sim.mask[:] = afwImage.Mask.getPlaneBitMask(\"BAD\")\n",
+    "\n",
+    "disp = afwDisplay.Display(reopenPlot=True)\n",
+    "\n",
+    "disp.scale('asinh', 'minmax', maskedPixels=\"BAD\")\n",
+    "disp.mtv(im)"
+   ]
   }
  ],
  "metadata": {
@@ -245,14 +279,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Support sexagesimal formatting of coordinates
   Either via a parameter to the ctor, or via an extension API;
   both called useSesagesimal

   Also make dpi a real arg, not kwargs (why did I do that?)
Fix matplotlib errors/warnings
Show WCS in degrees not radians
Set better vmax for asinh stretches
Add support for passing a matplotlib figure as the frame
set_colorbar() the default
Obey scale(..., maskedPixel=XXX)
   Currently only implemented for minmax; see DM-16565