### PR TITLE
DM-55580: Make mask display faster

### DIFF
--- a/python/lsst/display/matplotlib/matplotlib.py
+++ b/python/lsst/display/matplotlib/matplotlib.py
@@ -432,7 +432,12 @@ class DisplayImpl(virtualDevice.DisplayImpl):
         self._figure.canvas.draw_idle()
 
     def _i_mtv(self, data, wcs, title, isMask):
-        """Internal routine to display an Image or Mask on a DS9 display"""
+        """Internal routine to display an Image or Mask on a matplotlib
+        display.
+
+        Does not trigger a ``canvas.draw_idle`` command since it is assumed
+        that the caller will do that once all the layers have been added.
+        """
 
         title = str(title) if title else ""
         dataArr = data.getArray()
@@ -520,8 +525,6 @@ class DisplayImpl(virtualDevice.DisplayImpl):
                 mappable = ax.imshow(dataArr, origin='lower', interpolation='nearest',
                                      extent=extent, cmap=cmap, norm=norm)
                 self._mappable_ax = (mappable, ax)
-
-        self._figure.canvas.draw_idle()
 
     def _drawWcsAxes(self, ax, wcs):
         """Draw sky coordinate axes with AST, hiding the pixel axes.

--- a/python/lsst/display/matplotlib/matplotlib.py
+++ b/python/lsst/display/matplotlib/matplotlib.py
@@ -452,8 +452,6 @@ class DisplayImpl(virtualDevice.DisplayImpl):
 
             planeList = range(nMaskPlanes)
 
-            maskArr = np.zeros_like(dataArr, dtype=np.int32)
-
             colorNames = ['black']
             colorGenerator = self.display.maskColorGenerator(omitBW=True)
             for p in planeList:
@@ -497,24 +495,48 @@ class DisplayImpl(virtualDevice.DisplayImpl):
 
         with matplotlib.rc_context(dict(interactive=False)):
             if isMask:
-                for i, p in reversed(list(enumerate(planeList))):
-                    if colors[i + 1][alphaChannel] == 0:  # colors[0] is reserved
-                        continue
-
-                    bitIsSet = (dataArr & (1 << p)) != 0
-                    if bitIsSet.sum() == 0:
-                        continue
-
-                    maskArr[bitIsSet] = i + 1  # + 1 as we set colorNames[0] to black
-
-                    if not self._fastMaskDisplay:  # we draw each bitplane separately
-                        ax.imshow(maskArr, origin='lower', interpolation='nearest',
-                                  extent=extent, cmap=cmap, norm=norm)
-                        maskArr[:] = 0
-
-                if self._fastMaskDisplay:  # we only draw the lowest bitplane
+                if self._fastMaskDisplay:
+                    # Show only the lowest set bitplane in each pixel; a single
+                    # imshow of the plane indices suffices.
+                    maskArr = np.zeros_like(dataArr, dtype=np.int32)
+                    for i, p in reversed(list(enumerate(planeList))):
+                        if colors[i + 1][alphaChannel] == 0:  # colors[0] reserved
+                            continue
+                        bitIsSet = (dataArr & (1 << p)) != 0
+                        if not bitIsSet.any():
+                            continue
+                        maskArr[bitIsSet] = i + 1  # + 1 as colorNames[0] is black
                     ax.imshow(maskArr, origin='lower', interpolation='nearest',
                               extent=extent, cmap=cmap, norm=norm)
+                else:
+                    # Composite every visible bitplane into a single
+                    # full-resolution RGBA image and draw it as one layer.
+                    # The Porter-Duff "over" operator is associative, so
+                    # blending the planes here and drawing the result over the
+                    # image is identical to drawing each plane as its own
+                    # imshow, but matplotlib then colour-maps and resamples one
+                    # layer instead of one per set plane.  The planes are
+                    # composited in the same order they would be drawn
+                    # (highest plane first, so the lowest ends up on top).
+                    composite = np.zeros(dataArr.shape + (4,), dtype=np.float32)
+                    for i, p in reversed(list(enumerate(planeList))):
+                        alpha = colors[i + 1][alphaChannel]
+                        if alpha == 0:  # colors[0] is reserved
+                            continue
+                        bitIsSet = (dataArr & (1 << p)) != 0
+                        if not bitIsSet.any():
+                            continue
+                        # Place this plane's flat colour over the pixels
+                        # accumulated from higher planes (straight-alpha over).
+                        dst = composite[bitIsSet]
+                        dstAlpha = dst[:, 3:4]
+                        outAlpha = alpha + dstAlpha*(1.0 - alpha)
+                        composite[bitIsSet, :3] = \
+                            (colors[i + 1][:3]*alpha +
+                             dst[:, :3]*dstAlpha*(1.0 - alpha))/outAlpha
+                        composite[bitIsSet, 3] = outAlpha[:, 0]
+                    ax.imshow(composite, origin='lower', interpolation='nearest',
+                              extent=extent)
             else:
                 # If we're playing with subplots and have reset the axis
                 # the cached colorbar axis belongs to the old one, so set


### PR DESCRIPTION
* There was a imshow call that was  not needed because it was immediately followed by imshow.
* We were calling imshow per mask plane and that was not only causing rendering each time but also additional matplotlib overhead. This patch creates a high res composite mask image first and then hands it off to matplotlib once.