### PR TITLE
DM-55379 (hotfix): Space WCS axis labels for the post-colorbar axes size

### DIFF
--- a/python/lsst/display/matplotlib/matplotlib.py
+++ b/python/lsst/display/matplotlib/matplotlib.py
@@ -560,6 +560,13 @@ class DisplayImpl(virtualDevice.DisplayImpl):
         ax.set_xlim(*ax.get_xlim())
         ax.set_ylim(*ax.get_ylim())
 
+        # The colorbar is attached with an axes divider that only resizes
+        # this axes on the next draw.  AST spaces the labels using the
+        # axes geometry as it stands when it measures them, so realise the
+        # pending resize first; otherwise the labels are laid out for the
+        # wider, pre-colorbar axes and collide once the axes shrinks.
+        self._figure.draw_without_rendering()
+
         try:
             frameSet = astFrameSetFromWcs(wcs)
             self._wcsAxesManagers[ax] = WcsAxesManager(

--- a/python/lsst/display/matplotlib/wcsAxes.py
+++ b/python/lsst/display/matplotlib/wcsAxes.py
@@ -147,9 +147,13 @@ class WcsAxesManager:
         self._redrawing = False
         self._redrawTimer = None
         self._callbackIds = [
-            axes.callbacks.connect("xlim_changed", self._onLimitsChanged),
-            axes.callbacks.connect("ylim_changed", self._onLimitsChanged),
+            axes.callbacks.connect("xlim_changed", self._onViewChanged),
+            axes.callbacks.connect("ylim_changed", self._onViewChanged),
         ]
+        # A figure resize changes the axes size without changing the view
+        # limits, so the labels must be re-spaced for the new geometry too.
+        self._resizeCallbackId = axes.get_figure().canvas.mpl_connect(
+            "resize_event", self._onViewChanged)
 
         try:
             self.draw()
@@ -216,14 +220,17 @@ class WcsAxesManager:
     # event, and a full AST rebuild per event is far too slow.
     _redrawDelayMs = 200
 
-    def _onLimitsChanged(self, axes):
-        """Schedule a redraw for new view limits; matplotlib callback.
+    def _onViewChanged(self, event):
+        """Schedule a redraw after a view or size change; matplotlib callback.
 
-        The redraw is debounced with a one-shot timer so that a stream
-        of limit changes (interactive panning or zooming, or the x/y
-        pair from a single zoom) produces a single rebuild once the
-        view settles.  Backends without a running event loop cannot
-        fire timers, so there the redraw happens immediately.
+        Connected to the axes' ``xlim_changed``/``ylim_changed`` and the
+        canvas' ``resize_event``; the ``event`` argument (the axes or a
+        resize event) is unused.  The redraw is debounced with a one-shot
+        timer so that a stream of changes (interactive panning or zooming,
+        the x/y pair from a single zoom, or a drag-resize) produces a
+        single rebuild once the view settles.  Backends without a running
+        event loop cannot fire timers, so there the redraw happens
+        immediately.
         """
         if self._redrawing:
             return
@@ -275,6 +282,7 @@ class WcsAxesManager:
         for callbackId in self._callbackIds:
             self._axes.callbacks.disconnect(callbackId)
         self._callbackIds = []
+        self._axes.get_figure().canvas.mpl_disconnect(self._resizeCallbackId)
 
         self._removeArtists()
 

--- a/python/lsst/display/matplotlib/wcsAxes.py
+++ b/python/lsst/display/matplotlib/wcsAxes.py
@@ -146,14 +146,15 @@ class WcsAxesManager:
 
         self._redrawing = False
         self._redrawTimer = None
+        self._renderedSize = None
         self._callbackIds = [
-            axes.callbacks.connect("xlim_changed", self._onViewChanged),
-            axes.callbacks.connect("ylim_changed", self._onViewChanged),
+            axes.callbacks.connect("xlim_changed", self._onLimitsChanged),
+            axes.callbacks.connect("ylim_changed", self._onLimitsChanged),
         ]
         # A figure resize changes the axes size without changing the view
         # limits, so the labels must be re-spaced for the new geometry too.
         self._resizeCallbackId = axes.get_figure().canvas.mpl_connect(
-            "resize_event", self._onViewChanged)
+            "resize_event", self._onResize)
 
         try:
             self.draw()
@@ -205,6 +206,14 @@ class WcsAxesManager:
             if isinstance(artist, matplotlib.text.Text):
                 artist.set_clip_on(False)
 
+        # Record the size the labels were spaced for, so a later resize
+        # event that leaves the size unchanged can be ignored.
+        self._renderedSize = self._canvasSize()
+
+    def _canvasSize(self):
+        """Return the current canvas size in device pixels."""
+        return tuple(self._axes.get_figure().canvas.get_width_height())
+
     def _removeArtists(self):
         """Remove the AST artists from the axes."""
         for artist in self.artists:
@@ -220,17 +229,35 @@ class WcsAxesManager:
     # event, and a full AST rebuild per event is far too slow.
     _redrawDelayMs = 200
 
-    def _onViewChanged(self, event):
-        """Schedule a redraw after a view or size change; matplotlib callback.
+    def _onLimitsChanged(self, axes):
+        """Schedule a redraw for new view limits; matplotlib callback.
 
-        Connected to the axes' ``xlim_changed``/``ylim_changed`` and the
-        canvas' ``resize_event``; the ``event`` argument (the axes or a
-        resize event) is unused.  The redraw is debounced with a one-shot
-        timer so that a stream of changes (interactive panning or zooming,
-        the x/y pair from a single zoom, or a drag-resize) produces a
-        single rebuild once the view settles.  Backends without a running
-        event loop cannot fire timers, so there the redraw happens
-        immediately.
+        The ``axes`` argument (the axes the callback fired for) is unused.
+        """
+        self._scheduleRedraw()
+
+    def _onResize(self, event):
+        """Schedule a redraw for a new figure size; matplotlib callback.
+
+        The ``event`` argument (the resize event) is unused.  Interactive
+        web backends (e.g. ipympl) emit ``resize_event`` repeatedly at the
+        size the figure already has, and a redraw repaints the canvas,
+        which prompts yet another such event; acting on every one produces
+        an unbounded rebuild loop.  Rebuild only when the canvas has
+        actually changed size since it was last drawn.
+        """
+        if self._canvasSize() == self._renderedSize:
+            return
+        self._scheduleRedraw()
+
+    def _scheduleRedraw(self):
+        """Debounce a rebuild of the AST axes after a view or size change.
+
+        The redraw is debounced with a one-shot timer so that a stream of
+        changes (interactive panning or zooming, the x/y pair from a single
+        zoom, or a drag-resize) produces a single rebuild once the view
+        settles.  Backends without a running event loop cannot fire timers,
+        so there the redraw happens immediately.
         """
         if self._redrawing:
             return

--- a/tests/test_display_matplotlib.py
+++ b/tests/test_display_matplotlib.py
@@ -46,6 +46,21 @@ def makeTestWcs():
     )
 
 
+def makeFineTestWcs():
+    """Return a fine-scale TAN SkyWcs whose decimal labels are wide.
+
+    At this scale the numeric labels nearly fill the gap between ticks,
+    so any mismatch between the axes geometry AST measures against and
+    the geometry it is finally drawn at makes them overlap.
+    """
+    return afwGeom.makeSkyWcs(
+        crpix=lsst.geom.Point2D(150, 150),
+        crval=lsst.geom.SpherePoint(53.0876, -27.5207, lsst.geom.degrees),
+        cdMatrix=afwGeom.makeCdMatrix(scale=0.2*lsst.geom.arcseconds,
+                                      orientation=0*lsst.geom.degrees),
+    )
+
+
 class AstFrameSetTestCase(lsst.utils.tests.TestCase):
     """Tests for the SkyWcs to pyast FrameSet conversion."""
 
@@ -272,6 +287,41 @@ class WcsAxesDisplayTestCase(lsst.utils.tests.TestCase):
         ax = impl._figure.gca()
         manager = impl._wcsAxesManagers[ax]
         self.assertIn("Grid=1", manager._plotOptions())
+
+    def testLabelsDoNotOverlapColorbar(self):
+        """Numeric labels must be spaced for the axes as finally drawn.
+
+        The colorbar resizes the image axes, and AST must space the
+        labels for that final size rather than the full-width axes it
+        starts from, or wide decimal labels overlap.
+        """
+        exposure = afwImage.ExposureF(300, 300)
+        exposure.image.array[:] = 1.0
+        exposure.setWcs(makeFineTestWcs())
+
+        display = afwDisplay.Display(frame=self.frame)
+        display.mtv(exposure)
+        fig = display._impl._figure
+        ax = fig.gca()
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+
+        # Numeric tick labels drawn horizontally (the bottom, RA axis).
+        boxes = []
+        for artist in ax.texts:
+            text = artist.get_text()
+            if text in ("Right ascension", "Declination"):
+                continue
+            if any(c.isdigit() for c in text) and artist.get_rotation() % 180 == 0:
+                boxes.append(artist.get_window_extent(renderer))
+        # Keep the row nearest the bottom of the axes.
+        yBottom = min(box.y0 for box in boxes)
+        bottom = sorted((box for box in boxes if box.y0 < yBottom + 20),
+                        key=lambda box: box.x0)
+        self.assertGreater(len(bottom), 1)
+        for left, right in zip(bottom, bottom[1:]):
+            self.assertLessEqual(left.x1, right.x0,
+                                 "adjacent RA labels overlap")
 
     def testZoomRedraws(self):
         display = afwDisplay.Display(frame=self.frame)

--- a/tests/test_display_matplotlib.py
+++ b/tests/test_display_matplotlib.py
@@ -170,6 +170,21 @@ class WcsAxesManagerTestCase(lsst.utils.tests.TestCase):
         for artist in oldArtists:
             self.assertNotIn(artist, axesArtists)
 
+    def testResizeIgnoresUnchangedSize(self):
+        """A resize event at the current size must not trigger a rebuild.
+
+        Interactive web backends (e.g. ipympl) emit resize events
+        repeatedly at the size the figure already has, and a rebuild
+        repaints the canvas and prompts yet another event; acting on each
+        one drives an unbounded repaint loop.
+        """
+        from matplotlib.backend_bases import ResizeEvent
+
+        ax, manager = makeWcsAxes()
+        oldArtists = list(manager.artists)
+        ResizeEvent("resize_event", ax.get_figure().canvas)._process()
+        self.assertEqual(manager.artists, oldArtists)
+
     def testDebouncedRedraw(self):
         """With a working timer, drag events coalesce into one redraw."""
         from matplotlib.backend_bases import TimerBase

--- a/tests/test_display_matplotlib.py
+++ b/tests/test_display_matplotlib.py
@@ -154,6 +154,22 @@ class WcsAxesManagerTestCase(lsst.utils.tests.TestCase):
         for artist in oldArtists:
             self.assertNotIn(artist, axesArtists)
 
+    def testRedrawOnResize(self):
+        """Resizing the figure re-spaces the labels for the new geometry."""
+        from matplotlib.backend_bases import ResizeEvent
+
+        ax, manager = makeWcsAxes()
+        oldArtists = list(manager.artists)
+        fig = ax.get_figure()
+        fig.set_size_inches(3, 3)
+        ResizeEvent("resize_event", fig.canvas)._process()
+        self.assertGreater(len(manager.artists), 0)
+        self.assertNotEqual(manager.artists, oldArtists)
+        # The old artists must be gone from the axes.
+        axesArtists = set(ax.lines) | set(ax.texts)
+        for artist in oldArtists:
+            self.assertNotIn(artist, axesArtists)
+
     def testDebouncedRedraw(self):
         """With a working timer, drag events coalesce into one redraw."""
         from matplotlib.backend_bases import TimerBase


### PR DESCRIPTION
The colorbar is attached with an axes divider that only resizes the image axes on the next draw, but AST measured the label extents against the full-width axes it starts from. The axes then shrank, so wide decimal labels were laid out too densely and overlapped (and the axis title landed on top of the numeric labels). Realise the pending resize before AST measures so it spaces the labels for the final geometry.